### PR TITLE
Added win32 compatibility

### DIFF
--- a/Src/uno.c
+++ b/Src/uno.c
@@ -16,14 +16,17 @@
 
 #include <unistd.h>
 #include <signal.h>
-
+#if !defined(_WIN32)
 #ifndef BINDIR
 	#define BINDIR	"/usr/local/bin"
 #endif
 
 static char *lx = BINDIR"/uno_local";
 static char *gx	= BINDIR"/uno_global";
-
+#else
+static char *lx = "uno_local";
+static char *gx	= "uno_global";
+#endif
 static int  localonly, usecheck, quiet;
 static int  glob_base, verbose, glob_prop;
 static char *w_dir;
@@ -138,7 +141,11 @@ cleanup(int unused)
 
 	if ((int) strlen(glob_cmd) > glob_base && glob_base > 5)
 	{	memset(glob_cmd, ' ', glob_base);
+#if defined(_WIN32)
+        memcpy(glob_cmd, "del /Q", 6);
+#else
 		strncpy(glob_cmd, "rm -f", 5);
+#endif
 		if (w_dir)
 		{	char *p = malloc(strlen(glob_cmd) + strlen("cd ;") + strlen(w_dir) + 1);
 			sprintf(p, "cd %s; %s\n", w_dir, glob_cmd);


### PR DESCRIPTION
1. Bypass the BINDIR variable and just search executables in the same directory of uno.exe (no paths, just the base name, the 3 exe files must be in the same folder
2. Added "del /Q" option (rm -f was the only one present)

The only file changed is uno.c

With this changes, linux build remains untouched but gcc win32 compile/run correctly





